### PR TITLE
Containerize CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-slim-buster
+
+RUN mkdir -p /opt/jars
+
+COPY ./cli/target/scala-2.12/cli-assembly-0.1.0-SNAPSHOT.jar /opt/jars
+
+ENTRYPOINT ["java", "-Xmx3g", "-cp", "/opt/jars/cli-assembly-0.1.0-SNAPSHOT.jar", "com.rasterfoundry.conveyor.Conveyor", "new-project"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ $ docker run \
     --datasource=001d8582-376b-4d18-a93e-01ffe8fb0da8 # replace with a real datasource ID if desired
 ```
 
+Due to some kind of poorly understood behavior with connection channels,
+the program won't exit on its own, but you can `ctrl+c` it to kill
+it once you've seen `Waiting for upload completion` and `exhausted input` in the logs.
+
 ## Obtaining a refresh token
 
 To obtain a refresh token, follow instructions on the Raster Foundry [help page](https://help.rasterfoundry.com/en/articles/777804-generating-a-refresh-token-in-order-to-use-the-api).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ docker run \
     "Test project" \
     /opt/data/upload.tif \
     "refresh-token" \
-    --datasource=001d8582-376b-4d18-a93e-01ffe8fb0da8
+    --datasource=001d8582-376b-4d18-a93e-01ffe8fb0da8 # replace with a real datasource ID if desired
 ```
 
 ## Obtaining a refresh token

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 `conveyor` is a CLI for uploading local imagery into a new Raster Foundry project.
 
-If you have the build jar of this CLI, you can run:
+The CLI is published under `jisantuc/conveyor`. You can obtain the container with
+`docker pull jisantuc/conveyor:latest`, then:
 
 ```bash
-$ java -jar cli-assembly-0.1.0-SNAPSHOT.jar new-project
+$ docker run jisantuc/conveyor:latest
 Usage: conveyor new-project [--datasource <uuid>] <PROJECT_NAME> <TIFF_ABSOLUTE_PATH> <REFRESH_TOKEN>
 
 Upload an image to a new Raster Foundry project
@@ -17,27 +18,35 @@ Options and flags:
         Which datasource to associate with this imagery
 ```
 
-If you're developing and have [`bloop`](https://scalacenter.github.io/bloop/) on your
-path, you can run the above as:
-
-```bash
-$ bloop run cli -- new-project
-```
-
-Output will be the same.
-
 The program's arguments are:
 
 - `PROJECT_NAME`: the name to associate with your new project
-- `TIFF_ABSOLUTE_PATH`: a path to a GeoTIFF on your local file system
+- `TIFF_ABSOLUTE_PATH`: a path to a GeoTIFF in the container's file system
 - `REFRESH_TOKEN`: the refresh token to use to obtain a JSON Web Token from the Raster Foundry API
 
 It also optionally takes a datasource id in the `--datasource` option. If absent, the program will supply
 the id for a default 4 band datasource.
 
-For example, to create a project called "Good Imagery" with the file `good-imagery.tiff` in your home directory,
-you would run:
+A complete example with a bogus refresh token is shown below, including mounting the local directory with
+data into the container:
 
 ```bash
-$ java -jar cli-assembly-0.1.0-SNAPSHOT.jar new-project "Good Imagery" $HOME/good-imagery.tiff abcdefg
+$ docker run \
+    -v $(pwd)/data:/opt/data \
+    jisantuc/conveyor:latest \
+    "Test project" \
+    /opt/data/upload.tif \
+    "refresh-token" \
+    --datasource=001d8582-376b-4d18-a93e-01ffe8fb0da8
 ```
+
+## Obtaining a refresh token
+
+To obtain a refresh token, follow instructions on the Raster Foundry [help page](https://help.rasterfoundry.com/en/articles/777804-generating-a-refresh-token-in-order-to-use-the-api).
+While it notes you can only view a given refresh token once, you can create as many as you need, so don't panic if you accidentally
+click out of the modal before you copy the token. For ease of access, consider storing your refresh token in a password manager.
+
+## Finding a datasource ID
+
+You can find datasources in the ["Datasources" tab](https://app.rasterfoundry.com/imports/datasources/list?page=1) of the Raster Foundry data
+management UI. To find the ID for a given datasource, you can click the eye icon next to its name and copy its id from the URL.

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/cli/src/main/scala/Main.scala
+++ b/cli/src/main/scala/Main.scala
@@ -9,7 +9,7 @@ import com.monovore.decline.effect._
 import com.softwaremill.sttp
 import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
-object HelloWorld
+object Conveyor
     extends CommandIOApp(
       name = "conveyor",
       header = "Upload a tif to a Raster Foundry project"

--- a/cli/src/main/scala/programs/NewProjectProgram.scala
+++ b/cli/src/main/scala/programs/NewProjectProgram.scala
@@ -50,6 +50,7 @@ class NewProjectProgram(http: Http[IO]) {
       credentials <- http.getUploadCredentials(upload)
       _           <- http.uploadTiff(projectOpts.tiffPath, credentials)
       _           <- http.completeUpload(upload, credentials.bucketPath)
+      ()          <- IO { println("--------------\nUpload complete. Press ctrl+c at any time.\n--------------") }
     } yield ()).recoverWith({
       case err => IO { println(err.getMessage) }
     })


### PR DESCRIPTION
Overview
-----

This PR adds a Dockerfile with a convenient entrypoint for running the CLI. It also documents the
steps required to use the container to upload local imagery.

Notes
-----

We're still getting way too much console output, and the program still doesn't exit, but I considered those out of scope for the matter at hand.

Testing
-----

- follow the instructions in the README to upload a local tif
- it should succeed

Closes azavea/raster-foundry-platform#1173